### PR TITLE
Update keybinding regex to not be so loose

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -2,7 +2,7 @@
 	{
 		"keys": [";"], "command": "auto_semi_colon", "context": [
 			{ "key": "selector", "operator": "equal", "operand": "source - string" },
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(for(each)?|if|switch|while)[^\\{]+$", "match_all": true }
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\b(for(each)?|if|switch|while)\\s*\\(", "match_all": true }
 		]
 	}
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -2,7 +2,7 @@
 	{
 		"keys": [";"], "command": "auto_semi_colon", "context": [
 			{ "key": "selector", "operator": "equal", "operand": "source - string" },
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(for(each)?|if|switch|while)[^\\{]+$", "match_all": true }
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\b(for(each)?|if|switch|while)\\s*\\(", "match_all": true }
 		]
 	}
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -2,7 +2,7 @@
 	{
 		"keys": [";"], "command": "auto_semi_colon", "context": [
 			{ "key": "selector", "operator": "equal", "operand": "source - string" },
-			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "(for(each)?|if|switch|while)[^\\{]+$", "match_all": true }
+			{ "key": "preceding_text", "operator": "not_regex_contains", "operand": "\\b(for(each)?|if|switch|while)\\s*\\(", "match_all": true }
 		]
 	}
 ]


### PR DESCRIPTION
Currently this blocks semicolons from being inserted in places where
they should be allowed